### PR TITLE
Backup/restore from Ansible to KernelCI improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ The web ui is then available on port 8080 and the api on port 8081.
 
 ![Home](./images/kernelci-home.png)
 
-### Backup / restore a mongo database
+### Backup / restore KernelCI from Ansible
 
 You may have an already running version of kernelCI with data that you would like to keep.
 
@@ -155,7 +155,25 @@ This will create a `.tar.gz` file available on the mongo Host. You can now copy/
 To restore an existing mongo database dump (in .tar.gz format), run the following command:
 
 ```
-./seed.sh kernelci_db_dump.tar.gz
+./seed.sh -d kernelci_db_dump.tar.gz
+```
+/!\ This command needs to be run after `start.sh` once all the services are up and running.
+
+#### Backup the logs
+
+To do a backup of the boot/test logs on the previous KernelCI instance do:
+
+```
+tar czf kernelci_logs_dump.tar.gz -C /var/www/images/ kernel-ci
+```
+
+This will create a `.tar.gz` file available on the host. You can now copy/share it with the machine running kernelci-docker.
+
+#### Restore the logs
+
+To restore the logs from a backup (in .tar.gz format), run the following command:
+```
+./seed.sh -l kernelci_logs_dump.tar.gz
 ```
 /!\ This command needs to be run after `start.sh` once all the services are up and running.
 

--- a/seed.sh
+++ b/seed.sh
@@ -1,31 +1,48 @@
 #!/bin/bash
-set -x
-# Make sure dump file exist
-DUMP_FILE=$1
-if [ ! -e "$DUMP_FILE" ];then
-    echo "-> please provide an exiting dump file"
-    exit 1
+
+while getopts "d:l:" option
+do
+    case $option in
+        d) DB_DUMP_FILE=$OPTARG;;
+        l) LOG_DUMP_FILE=$OPTARG;;
+    esac
+done
+
+if [ ! "$DB_DUMP_FILE" ] && [ ! "$LOG_DUMP_FILE" ];then
+    echo "Usage: ./seed.sh -d DATABASE_BACKUP.tar.gz -l LOG_BACKUP.tar.gz"
 fi
 
-## Get db container
-ID=$(docker ps -q --filter "label=com.docker.swarm.service.name=kernelci_mongo" 2>/dev/null)
-if [ "$ID" = "" ];then
-  echo "--Container for service kernelci_mongo not found exiting--"
-  exit 1
+if [ ! -z "$DB_DUMP_FILE" ];then
+    echo "-->Restoring Mongo database from $DB_DUMP_FILE"
+    ## Get db container
+    ID=$(docker ps -q --filter "label=com.docker.swarm.service.name=kernelci_mongo" 2>/dev/null)
+    if [ "$ID" = "" ];then
+      echo "--Container for service kernelci_mongo not found exiting--"
+      exit 1
+    fi
+
+    ## Copy dump to container
+    tar xvf $DB_DUMP_FILE
+    if [ $? -eq 0 ];then
+      echo "--Database backup extracted correctly--"
+    else
+      echo "--Something went wrong wile extracting the database from $DB_DUMP_FILE--"
+      exit 1
+    fi
+    DUMP_FOLDER=$(sed -e 's/.tar.gz//' <<<$DB_DUMP_FILE)
+    docker cp $DUMP_FOLDER $ID:/tmp
+    rm -r ./$DUMP_FOLDER
+
+    ## Restore dump
+    docker exec $ID /bin/bash -c "mongorestore --db=kernel-ci /tmp/$DUMP_FOLDER/kernel-ci"
 fi
 
-## Copy dump to container
-tar xvf $DUMP_FILE
-if [ $? -eq 0 ];then
-  echo "--Databse backup extracted correctly--"
-else
-  echo "--Something went wrong wile extracting the database from $DUMP_FILE--"
-  exit 1
+if [ ! -z "$LOG_DUMP_FILE" ];then
+    echo "-->Restoring logs database from $LOG_DUMP_FILE"
+    ## Restore logs
+    tar xvf $LOG_DUMP_FILE
+    docker run --rm -v `pwd`/kernel-ci/:/tmp/kernelci_logs/ -v kernelci_kci:/var/lib/docker/volumes/kernelci_kci/_data busybox cp -r /tmp/kernelci_logs/. /var/lib/docker/volumes/kernelci_kci/_data
+    rm -r kernel-ci/
 fi
-DUMP_FOLDER=$(sed -e 's/.tar.gz//' <<<$DUMP_FILE)
-docker cp $DUMP_FOLDER $ID:/tmp
-rm -r ./$DUMP_FOLDER
 
-## Restore dump
-docker exec $ID /bin/bash -c "mongorestore --db=kernel-ci /tmp/$DUMP_FOLDER/kernel-ci"
 exit 0


### PR DESCRIPTION
Add documentation and a script to backup and restore logs from a
kernelci-ansible instance to a kernelci-docker one.

Signed-off-by: Loys Ollivier <lollivier@baylibre.com>