### PR TITLE
start.sh: Add export var to get latest stable version

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+export TAG=1.0
 STACK_NAME="kernelci"
 
 ## Prerequisites


### PR DESCRIPTION
As the start.sh script is intended to be used for production it should
pull the stable images version and not latest.

Add export to specify to use the 1.0 version.

Signed-off-by: Loys Ollivier <lollivier@baylibre.com>