### PR TITLE
gitignore: ignore more logs files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 config/*.config
 frontend/flask_settings
 search/test
-search/log/log-*.log
+search/log/*.log
+search/log/*-done
 vagrant/.vagrant
 .kernelci_token


### PR DESCRIPTION
Not all the log file start with log-* so just ignore all of *.log.
While we're at it, also ignore *-done.

Signed-off-by: Kevin Hilman <khilman@baylibre.com>