### PR TITLE
start.sh: export TAG

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -11,7 +11,7 @@ do
 done
 
 # Use "latest" if no tag is specified
-TAG=${TAG:-latest}
+export TAG=${TAG:-latest}
 
 ## Prerequisites
 


### PR DESCRIPTION
The TAG env variable needs to be exported in order for it to
override what's used in docker-stack.yml

Signed-off-by: Kevin Hilman <khilman@baylibre.com>