### PR TITLE
dev-start.sh: fix setting of frontend token

### DIFF
--- a/dev-start.sh
+++ b/dev-start.sh
@@ -69,7 +69,7 @@ echo "-> token returned: $TOKEN"
 
 ### Update frontend with token created
 
-sed -i "" -e "s/^BACKEND_TOKEN.*$/BACKEND_TOKEN = \"$TOKEN\"/" frontend/flask_settings
+sed -i "s/^BACKEND_TOKEN.*$/BACKEND_TOKEN = \"$TOKEN\"/" frontend/flask_settings
 
 echo "-> wait while frontend is restarted"
 docker-compose stop frontend || exit $?


### PR DESCRIPTION
When starting kernelci-docker with dev-start.sh, the log show a "no such
file or directory", it is the "frontend token sed" which fail.
Furthermore, the new frontend token is not setted.

This patch fix the sed command to made it works.